### PR TITLE
Remove getOuterContainerRef from Lua API

### DIFF
--- a/docs/Lua API.rst
+++ b/docs/Lua API.rst
@@ -1196,10 +1196,6 @@ Units module
 
   Returns the container (cage) item or *nil*.
 
-* ``dfhack.units.getOuterContainerRef(unit)``
-
-  Returns a specific_ref struct of the outermost object that contains the unit (or one of the unit itself.) Possible ref types are ``UNIT``, ``ITEM_GENERAL``, or ``VERMIN_EVENT``.
-
 * ``dfhack.units.setNickname(unit,nick)``
 
   Sets the unit's nickname properly.
@@ -1418,10 +1414,6 @@ Items module
 * ``dfhack.items.getContainer(item)``
 
   Returns the container item or *nil*.
-
-* ``dfhack.items.getOuterContainerRef(item)``
-
-  Returns a specific_ref struct of the outermost object that contains the item (or one of the item itself.) Possible ref types are ``UNIT``, ``ITEM_GENERAL``, or ``VERMIN_EVENT``.
 
 * ``dfhack.items.getContainedItems(item)``
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -58,7 +58,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Lua
 - ``argparse.processArgsGetopt()``: you can now have long form parameters that are not an alias for a short form parameter. For example, you can now have a parameter like ``--longparam`` without needing to have an equivalent one-letter ``-l`` param.
 - ``dwarfmode.enterSidebarMode()``: ``df.ui_sidebar_mode.DesignateMine`` is now a suported target sidebar mode
-- Lua wrappers for functions reverse-engineered from ambushing unit code: ``isHidden(unit)``, ``isFortControlled(unit)``, ``getOuterContainerRef(unit)``, ``getOuterContainerRef(item)``
+- Lua wrappers for functions reverse-engineered from ambushing unit code: ``isHidden(unit)``, ``isFortControlled(unit)``
 
 ## Documentation
 - Lua API.rst added: ``isHidden(unit)``, ``isFortControlled(unit)``, ``getOuterContainerRef(unit)``, ``getOuterContainerRef(item)``

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -1657,7 +1657,6 @@ static const LuaWrapper::FunctionReg dfhack_units_module[] = {
     WRAPM(Units, getMainSocialEvent),
     WRAPM(Units, getStressCategory),
     WRAPM(Units, getStressCategoryRaw),
-    WRAPN(getOuterContainerRef, (df::specific_ref(*)(df::unit*))Units::getOuterContainerRef),
     { NULL, NULL }
 };
 
@@ -1792,7 +1791,6 @@ static const LuaWrapper::FunctionReg dfhack_items_module[] = {
     WRAPM(Items, canTradeWithContents),
     WRAPM(Items, isRouteVehicle),
     WRAPM(Items, isSquadEquipment),
-    WRAPN(getOuterContainerRef, (df::specific_ref (*)(df::item*))Items::getOuterContainerRef),
     WRAPN(moveToGround, items_moveToGround),
     WRAPN(moveToContainer, items_moveToContainer),
     WRAPN(moveToInventory, items_moveToInventory),


### PR DESCRIPTION
Don't think this works properly without allocating a new specific_ref. More trouble that it's worth.